### PR TITLE
Migrate to OIDC tokens

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,21 +4,32 @@ on:
   push:
     branches:
       - release
+  workflow_dispatch:              # lets you trigger a manual test run
+
+permissions:
+  id-token: write                 # REQUIRED for OIDC
+  contents: read
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
-      - name: Setup .npmrc file to publish to npm
-        uses: actions/setup-node@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
         with:
-          node-version: '16'
+          node-version: '24'                          # 22.14.0+ is the floor
           registry-url: 'https://registry.npmjs.org'
-      - name: Enable Corepack before setting up Node
+          package-manager-cache: false                # don't cache in release builds
+
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest                # ensures npm >= 11.5.1
+
+      - name: Enable Corepack
         run: corepack enable
+
       - name: Setup git identity
         run: |
           git config --global user.email "github@digitalsamba.com"
@@ -27,16 +38,8 @@ jobs:
       - name: Set Yarn version
         run: corepack prepare yarn@3.1.0 --activate
 
-      - name: execute yarn
+      - name: Install dependencies
         run: yarn
 
-      - name: Configure npm authentication
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
-      - name: Debug - Check npm token
-        run: cat ~/.npmrc
-
-      - name: yarn publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public
-
+      - name: Publish to npm
+        run: npm publish --access public              # no NODE_AUTH_TOKEN here — OIDC handles it


### PR DESCRIPTION
npm will drop support by the end of the year manual tokens, so we are migrating to OIDC